### PR TITLE
Add an option to ceate local (dummy) services of type NodePort

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Imaging there is cluster X and Y (Nodes Xn and Yn) with barrelman running as Xb 
 * Create Service "foo/bar" (type NodePort) in X
     * Namespace "foo" is created in Y
     * Service "foo/bar" (Type: ClusterIP, targetPort == NodePort of "foo/bar" in X) is created in Y
-    * Endpoint(s) "foo/bar" are created in Y (pointing to Xn:targetPort)
+    * Endpoint(s) "foo/bar" are created in Y (pointing to Xn:nodePort)
 * Change NodePort of service "foo/bar" in X
     * targetPort of service "foo/bar" in Y is updated accordingly
     * Endpoint(s) "foo/bar" in Y are updated accordingly

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ Watch for changes of services objects in _remote-cluster_:
     * All service ports of the remote service
 * Delete: Remove dummy service in _local-cluster_ if it was created by barrelman
 
+Services in _local-cluster_ will be created with type ClusterIP by default. If you want to them to be type NodePort
+instead, run _barrelman_ with the `-nodeportsvc` switch (the services will maintain the same NodePort as in
+_remote-cluster_).
+
+
 ### What to expect
 Imaging there is cluster X and Y (Nodes Xn and Yn) with barrelman running as Xb and Yb.
 

--- a/helm/barrelman/Chart.yaml
+++ b/helm/barrelman/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "0.2.0"
 description: Kubernetes controller that watches a remote cluster for node changes and updates service endpoints accordingly
 name: barrelman
-version: 0.1.0
+version: 0.2.0

--- a/helm/barrelman/templates/deployment.yaml
+++ b/helm/barrelman/templates/deployment.yaml
@@ -40,6 +40,9 @@ spec:
             - "{{ .Values.barrelman.scWorkers }}"
             - -v
             - "{{ .Values.barrelman.verbosity }}"
+            {{- if .Values.barrelman.nodePortSvc }}
+            - -nodeportsvc
+            {{- end }}
           env:
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: "/gcloud/credentials.json"

--- a/helm/barrelman/values.yaml
+++ b/helm/barrelman/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: "traumfewo/barrelman"
-  tag: "v0.1.0"
+  tag: "v0.2.0"
   pullPolicy: IfNotPresent
 
 nameOverride: ""
@@ -19,6 +19,7 @@ barrelman:
   verbosity: "2"
   necWorkers: "4"
   scWorkers: "2"
+  nodePortSvc: false
   remote:
     project: "undefined"
     zone: "undefined"

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ var (
 	resyncPeriod      = flag.Duration("resync-period", 2*time.Hour, "how often should all nodes be considered \"old\" (and processed again)")
 	necWorkers        = flag.Uint("nec-workers", 4, "number of workers for NodeEndpointController")
 	scWorkers         = flag.Uint("sc-workers", 2, "number of workers for ServiceController")
+	createNodePortSvc = flag.Bool("nodeportsvc", false, "create services of type NodePort in \"local\" cluster (instead of ClusterIP)")
 	// See init() for "ignore-namespace"
 )
 
@@ -144,8 +145,8 @@ func main() {
 
 	serviceController := controller.NewServiceController(
 		localClientset, remoteClientset,
-		remoteInformerFactory.Core().V1().Services(),
-		localInformerFactory.Core().V1().Services(),
+		remoteInformerFactory.Core().V1().Services(), localInformerFactory.Core().V1().Services(),
+		*createNodePortSvc,
 	)
 
 	// Ramp up the informer loops


### PR DESCRIPTION
This will use the same NodePort as in remote service for the local ones.